### PR TITLE
Allow fitting for Vsini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ h5py = "^3.11.0"
 pyqt5 = "^5.15.10"
 single-source = "^0.4.0"
 scipy = "^1.13"
+pyastronomy = ">=0.21.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/spexxy/component/spectrumcomponent.py
+++ b/spexxy/component/spectrumcomponent.py
@@ -16,7 +16,7 @@ class SpectrumComponent(Component):
     """SpectrumComponent is the base Component class for all components that deal with spectra."""
 
     def __init__(self, name: str, broadening_type: str = 'LOSVD', losvd_hermite: bool = False,
-                 vsini_epsilon: bool = False, vac_to_air: bool = False, lsf: Union[LSF, str, dict] = None,
+                 vac_to_air: bool = False, lsf: Union[LSF, str, dict] = None,
                  *args, **kwargs):
         """Initializes a new SpectrumComponent.
 
@@ -24,7 +24,6 @@ class SpectrumComponent(Component):
             name: Name of new component
             broadening_type: Type of broadening (LOSVD, VSINI)
             losvd_hermite: Whether Hermite polynomials should be used for the LOSVD
-            vsini_epsilon: Whether limb darkening parameter should be used for the VSINI.
             vac_to_air: If True, vac_to_air() is called on spectra returned from the model_func
             lsf: LSF to apply to spectrum
         """
@@ -32,7 +31,6 @@ class SpectrumComponent(Component):
         self._vac_to_air = vac_to_air
         self._broadening_type = broadening_type
         self._losvd_hermite = losvd_hermite
-        self._vsini_epsilon = vsini_epsilon
 
         # add losvd parameters
         self.set('v', min=-2000., max=2000., value=1.)
@@ -45,8 +43,7 @@ class SpectrumComponent(Component):
                 self.set('h6', min=-0.3, max=0.3, value=0.)
         elif self._broadening_type == 'VSINI':
             self.set('vsini', min=0, max=800., value=20.)
-            if self._vsini_epsilon:
-                self.set('epsilon', min=0., max=1., value=0.5)
+            self.set('epsilon', min=0., max=1., value=0.5)
 
         # get lsf
         if isinstance(lsf, LSF):
@@ -81,7 +78,7 @@ class SpectrumComponent(Component):
         if self._broadening_type == 'LOSVD':
             losvd_params = ['v', 'sig'] + (['h3', 'h4', 'h5', 'h6'] if self._losvd_hermite else [])
         elif self._broadening_type == 'VSINI':
-            losvd_params = ['v', 'vsini'] + (['epsilon'] if self._vsini_epsilon else [])
+            losvd_params = ['v', 'vsini', 'epsilon']
         else:
             raise ValueError('Unknown broadening type: ', self._broadening_type)
         losvd = [self[p] for p in losvd_params]

--- a/spexxy/component/spectrumcomponent.py
+++ b/spexxy/component/spectrumcomponent.py
@@ -1,5 +1,5 @@
 import os
-# from enum import Enum
+from enum import Enum
 from typing import Callable, Union
 
 from .component import Component
@@ -7,16 +7,16 @@ from ..data import LOSVD, Vsini, Spectrum, LSF
 from ..object import create_object
 
 
-# class Broadening(Enum):
-#     LOSVD = 1
-#     VSINI = 2
+class Broadening(Enum):
+    LOSVD = 1
+    VSINI = 2
 
 
 class SpectrumComponent(Component):
     """SpectrumComponent is the base Component class for all components that deal with spectra."""
 
-    def __init__(self, name: str, broadening_type: str = 'LOSVD', losvd_hermite: bool = False,
-                 vac_to_air: bool = False, lsf: Union[LSF, str, dict] = None,
+    def __init__(self, name: str, broadening_type: Broadening = Broadening.LOSVD, losvd_hermite: bool = False,
+                 fast_vsini: bool = True, vac_to_air: bool = False, lsf: Union[LSF, str, dict] = None,
                  *args, **kwargs):
         """Initializes a new SpectrumComponent.
 
@@ -24,24 +24,31 @@ class SpectrumComponent(Component):
             name: Name of new component
             broadening_type: Type of broadening (LOSVD, VSINI)
             losvd_hermite: Whether Hermite polynomials should be used for the LOSVD
+            fast_vsini: Whether to use the fast or the accurate Vsini routine from PyAstronomy
             vac_to_air: If True, vac_to_air() is called on spectra returned from the model_func
             lsf: LSF to apply to spectrum
         """
         Component.__init__(self, name, *args, **kwargs)
         self._vac_to_air = vac_to_air
-        self._broadening_type = broadening_type
+        if isinstance(broadening_type, int):
+            self._broadening_type = Broadening(broadening_type)
+        elif isinstance(broadening_type, str):
+            self._broadening_type = Broadening[broadening_type]
+        else:
+            self._broadening_type = broadening_type
         self._losvd_hermite = losvd_hermite
+        self._fast_vsini = fast_vsini
 
         # add losvd parameters
         self.set('v', min=-2000., max=2000., value=1.)
-        if self._broadening_type == 'LOSVD':
+        if self._broadening_type == Broadening.LOSVD:
             self.set('sig', min=0., max=500., value=10.)
             if self._losvd_hermite:
                 self.set('h3', min=-0.3, max=0.3, value=0.)
                 self.set('h4', min=-0.3, max=0.3, value=0.)
                 self.set('h5', min=-0.3, max=0.3, value=0.)
                 self.set('h6', min=-0.3, max=0.3, value=0.)
-        elif self._broadening_type == 'VSINI':
+        elif self._broadening_type == Broadening.VSINI:
             self.set('vsini', min=0, max=800., value=20.)
             self.set('epsilon', min=0., max=1., value=0.5)
 
@@ -75,9 +82,9 @@ class SpectrumComponent(Component):
                 self.set(key, value=val)
 
         # get LOSVD parameters
-        if self._broadening_type == 'LOSVD':
+        if self._broadening_type == Broadening.LOSVD:
             losvd_params = ['v', 'sig'] + (['h3', 'h4', 'h5', 'h6'] if self._losvd_hermite else [])
-        elif self._broadening_type == 'VSINI':
+        elif self._broadening_type == Broadening.VSINI:
             losvd_params = ['v', 'vsini', 'epsilon']
         else:
             raise ValueError('Unknown broadening type: ', self._broadening_type)
@@ -102,7 +109,7 @@ class SpectrumComponent(Component):
         return model
 
     @staticmethod
-    def _apply_losvd(model, losvd, broadening_type='LOSVD'):
+    def _apply_losvd(model, losvd, broadening_type=Broadening.LOSVD, **kwargs):
         """Apply LOSVD with the given parameters to the given model.
 
         WARNING: We will NOT FIT line broadening, if model spectra are in LAMBDA mode!
@@ -113,11 +120,12 @@ class SpectrumComponent(Component):
                    Gauss-Hermite (LOSVD): (v, sig, <h3, h4, h5, h6>)
                    Rotational (VSINI): (v, vsini, epsilon)
             broadening_type: Broadening method to use.
+            kwargs: Parameters used to initialize broadening class.
         """
         if losvd[1] < 1e-5 or model.wave_mode == Spectrum.Mode.LAMBDA:
             # in LAMBDA mode, no LOSVD is supported
             model.redshift(losvd[0])
-        elif broadening_type == 'LOSVD':
+        elif broadening_type == Broadening.LOSVD:
             # full LOSVD for sig>0 and LOG mode
             if model.wave_step == 0:
                 # resample to const, if necessary
@@ -125,9 +133,10 @@ class SpectrumComponent(Component):
             # apply losvd
             losvd = LOSVD(losvd)
             model.flux = losvd(model)
-        elif broadening_type == 'VSINI':
+        elif broadening_type == Broadening.VSINI:
+            fast = kwargs.pop('fast', True)
             # initialize Vsini application
-            kernel = Vsini(losvd)
+            kernel = Vsini(losvd, fast=fast)
             # apply it
             model.flux = kernel(model)
 

--- a/spexxy/component/spectrumcomponent.py
+++ b/spexxy/component/spectrumcomponent.py
@@ -132,7 +132,7 @@ class SpectrumComponent(Component):
             elif broadening_type == Broadening.VSINI:
                 kernel = Vsini(losvd)
             # apply it
-            model.flux = losvd(model)
+            model.flux = kernel(model)
 
 
 __all__ = ['SpectrumComponent']

--- a/spexxy/data/__init__.py
+++ b/spexxy/data/__init__.py
@@ -2,6 +2,7 @@ from .filter import Filter
 from .fitsspectrum import FitsSpectrum
 from .isochrone import Isochrone, MultiIsochrone
 from .losvd import LOSVD
+from .vsini import Vsini
 from .lsf import LSF, AnalyticalLSF, EmpiricalLSF
 from .resultsfits import ResultsFITS
 from .spectrum import Spectrum, SpectrumFits, SpectrumFitsHDU, SpectrumBinTableFITS, SpectrumHiResFITS, SpectrumAscii

--- a/spexxy/data/vsini.py
+++ b/spexxy/data/vsini.py
@@ -1,0 +1,70 @@
+import numpy as np
+from typing import Tuple
+from PyAstronomy import pyasl
+
+from spexxy.data.spectrum import Spectrum
+
+
+class Vsini:
+
+    def __init__(self, params: Tuple):
+
+        self._vsini = list(params)
+
+    def __call__(self, spec: Spectrum) -> np.ndarray:
+        """Convolves a spectrum with the given Vsini kernel
+
+        Args:
+            spec (Spectrum): Spectrum to convolve
+
+        Returns
+            np.ndarray: Convolved spectrum
+        """
+        # Problem is that Spexxy requires log-sampled templates when applying broadening kernel, while PyAstronomy
+        # currently only works with spectra regularly sampled in linear space.
+
+        # spectrum in log mode?
+        if spec.wave_mode != Spectrum.Mode.LOGLAMBDA:
+            raise ValueError("Spectrum must be on log wavelength.")
+
+        # create copy of original spectrum for following operations
+        tmp = spec.copy()
+
+        # apply velocity shift
+        tmp.redshift(vrad=self._vsini[0])
+
+        # create regular sampling in linear space
+        tmp.mode(Spectrum.Mode.LAMBDA)
+        spec_lin = tmp.resample_const()
+
+        # apply broadening
+        spec_lin.flux = pyasl.rotBroad(spec_lin.wave, spec_lin.flux, epsilon=self._vsini[2], vsini=self._vsini[1])
+
+        # recover original sampling & return
+        spec_lin.mode(spec.wave_mode)
+        final = spec_lin.resample(spec=spec)
+
+        # make sure return value has no NaNs
+        return np.nan_to_num(final.flux)
+
+
+__all__ = ['Vsini']
+
+
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+    from spexxy.data import FitsSpectrum
+    from spexxy.data import LOSVD
+
+    fs = FitsSpectrum('/Users/ariskama/Downloads/lte11200-4.50-0.5.PHOENIX-ACES-AGSS-COND-2011-HiRes.fits')
+    kernel = Vsini(params=[100., 100., 0.5])
+    out = kernel(fs.spectrum)
+
+    losvd = LOSVD(params=[100., 100., 0., 0., 0.])
+    alt = losvd(fs.spectrum)
+
+    fig, ax = plt.subplots()
+    ax.plot(fs.spectrum.wave, fs.spectrum.flux, 'g-')
+    ax.plot(fs.spectrum.wave, out, 'b-')
+    ax.plot(fs.spectrum.wave, alt, r'--')
+    plt.show()

--- a/spexxy/data/vsini.py
+++ b/spexxy/data/vsini.py
@@ -55,7 +55,7 @@ class Vsini:
 
 __all__ = ['Vsini']
 
-#
+
 # if __name__ == "__main__":
 #     import time
 #     import matplotlib.pyplot as plt
@@ -64,11 +64,11 @@ __all__ = ['Vsini']
 #
 #     fs = FitsSpectrum('/Users/ariskama/Downloads/lte11200-4.50-0.5.PHOENIX-ACES-AGSS-COND-2011-HiRes.fits')
 #     t0 = time.time()
-#     kernel = Vsini(params=[100., 200., 0.5])
+#     kernel = Vsini(params=[100., 200, 0.5])
 #     out = kernel(fs.spectrum)
 #     t1 = time.time()
 #
-#     losvd = LOSVD(params=[100., 100., 0., 0., 0.])
+#     losvd = LOSVD(params=[100., 100, 0., 0., 0.])
 #     alt = losvd(fs.spectrum)
 #     t2 = time.time()
 #     print(t1-t0, t2-t1)

--- a/spexxy/data/vsini.py
+++ b/spexxy/data/vsini.py
@@ -7,9 +7,10 @@ from spexxy.data.spectrum import Spectrum
 
 class Vsini:
 
-    def __init__(self, params: Tuple):
+    def __init__(self, params: Tuple, fast: bool = True):
 
         self._vsini = list(params)
+        self._fast = fast
 
     def __call__(self, spec: Spectrum) -> np.ndarray:
         """Convolves a spectrum with the given Vsini kernel
@@ -38,7 +39,11 @@ class Vsini:
         spec_lin = tmp.resample_const()
 
         # apply broadening
-        spec_lin.flux = pyasl.fastRotBroad(spec_lin.wave, spec_lin.flux, epsilon=self._vsini[2], vsini=self._vsini[1])
+        if self._fast:
+            func = pyasl.fastRotBroad
+        else:
+            func = pyasl.rotBroad
+        spec_lin.flux = func(spec_lin.wave, spec_lin.flux, epsilon=self._vsini[2], vsini=self._vsini[1])
 
         # recover original sampling & return
         spec_lin.mode(spec.wave_mode)
@@ -50,26 +55,26 @@ class Vsini:
 
 __all__ = ['Vsini']
 
-
-if __name__ == "__main__":
-    import time
-    import matplotlib.pyplot as plt
-    from spexxy.data import FitsSpectrum
-    from spexxy.data import LOSVD
-
-    fs = FitsSpectrum('/Users/ariskama/Downloads/lte11200-4.50-0.5.PHOENIX-ACES-AGSS-COND-2011-HiRes.fits')
-    t0 = time.time()
-    kernel = Vsini(params=[100., 200., 0.5])
-    out = kernel(fs.spectrum)
-    t1 = time.time()
-
-    losvd = LOSVD(params=[100., 100., 0., 0., 0.])
-    alt = losvd(fs.spectrum)
-    t2 = time.time()
-    print(t1-t0, t2-t1)
-
-    fig, ax = plt.subplots()
-    ax.plot(fs.spectrum.wave, fs.spectrum.flux, 'g-')
-    ax.plot(fs.spectrum.wave, out, 'b-')
-    ax.plot(fs.spectrum.wave, alt, r'--')
-    plt.show()
+#
+# if __name__ == "__main__":
+#     import time
+#     import matplotlib.pyplot as plt
+#     from spexxy.data import FitsSpectrum
+#     from spexxy.data import LOSVD
+#
+#     fs = FitsSpectrum('/Users/ariskama/Downloads/lte11200-4.50-0.5.PHOENIX-ACES-AGSS-COND-2011-HiRes.fits')
+#     t0 = time.time()
+#     kernel = Vsini(params=[100., 200., 0.5])
+#     out = kernel(fs.spectrum)
+#     t1 = time.time()
+#
+#     losvd = LOSVD(params=[100., 100., 0., 0., 0.])
+#     alt = losvd(fs.spectrum)
+#     t2 = time.time()
+#     print(t1-t0, t2-t1)
+#
+#     fig, ax = plt.subplots()
+#     ax.plot(fs.spectrum.wave, fs.spectrum.flux, 'g-')
+#     ax.plot(fs.spectrum.wave, out, 'b-')
+#     ax.plot(fs.spectrum.wave, alt, r'--')
+#     plt.show()

--- a/spexxy/data/vsini.py
+++ b/spexxy/data/vsini.py
@@ -54,9 +54,6 @@ class Vsini:
         kernel = profile.evaluate(vel)
         out = np.convolve(spec.flux, kernel, mode="same")
 
-        fig, ax = plt.subplots()
-        ax.plot(vel, kernel, 'gx')
-
         # return final spectrum
         if int_shift == 0:
             # make sure return value has no NaNs

--- a/spexxy/data/vsini.py
+++ b/spexxy/data/vsini.py
@@ -62,19 +62,26 @@ __all__ = ['Vsini']
 #     from spexxy.data import FitsSpectrum
 #     from spexxy.data import LOSVD
 #
-#     fs = FitsSpectrum('/Users/ariskama/Downloads/lte11200-4.50-0.5.PHOENIX-ACES-AGSS-COND-2011-HiRes.fits')
+#     # fs = FitsSpectrum('/Users/ariskama/Downloads/lte11200-4.50-0.5.PHOENIX-ACES-AGSS-COND-2011-HiRes.fits')
+#     fs =  FitsSpectrum('/Users/ariskama/Downloads/lsfspec_teff8000_logg4.4_feh-0.35.fits')
 #     t0 = time.time()
-#     kernel = Vsini(params=[100., 200, 0.5])
-#     out = kernel(fs.spectrum)
+#
+#     kernel_fast = Vsini(params=[100., 200, 0.5], fast=True)
+#     fast = kernel_fast(fs.spectrum)
 #     t1 = time.time()
+#
+#     kernel_slow = Vsini(params=[100., 200, 0.5], fast=False)
+#     slow = kernel_slow(fs.spectrum)
+#     t2 = time.time()
 #
 #     losvd = LOSVD(params=[100., 100, 0., 0., 0.])
 #     alt = losvd(fs.spectrum)
-#     t2 = time.time()
-#     print(t1-t0, t2-t1)
+#     t3 = time.time()
+#     print(t1-t0, t2-t1, t3-t2)
 #
 #     fig, ax = plt.subplots()
 #     ax.plot(fs.spectrum.wave, fs.spectrum.flux, 'g-')
-#     ax.plot(fs.spectrum.wave, out, 'b-')
-#     ax.plot(fs.spectrum.wave, alt, r'--')
+#     ax.plot(fs.spectrum.wave, fast, 'b-')
+#     ax.plot(fs.spectrum.wave, slow, 'g:')
+#     ax.plot(fs.spectrum.wave, alt, 'r--')
 #     plt.show()

--- a/spexxy/data/vsini.py
+++ b/spexxy/data/vsini.py
@@ -38,7 +38,7 @@ class Vsini:
         spec_lin = tmp.resample_const()
 
         # apply broadening
-        spec_lin.flux = pyasl.rotBroad(spec_lin.wave, spec_lin.flux, epsilon=self._vsini[2], vsini=self._vsini[1])
+        spec_lin.flux = pyasl.fastRotBroad(spec_lin.wave, spec_lin.flux, epsilon=self._vsini[2], vsini=self._vsini[1])
 
         # recover original sampling & return
         spec_lin.mode(spec.wave_mode)
@@ -52,16 +52,21 @@ __all__ = ['Vsini']
 
 
 if __name__ == "__main__":
+    import time
     import matplotlib.pyplot as plt
     from spexxy.data import FitsSpectrum
     from spexxy.data import LOSVD
 
     fs = FitsSpectrum('/Users/ariskama/Downloads/lte11200-4.50-0.5.PHOENIX-ACES-AGSS-COND-2011-HiRes.fits')
-    kernel = Vsini(params=[100., 100., 0.5])
+    t0 = time.time()
+    kernel = Vsini(params=[100., 200., 0.5])
     out = kernel(fs.spectrum)
+    t1 = time.time()
 
     losvd = LOSVD(params=[100., 100., 0., 0., 0.])
     alt = losvd(fs.spectrum)
+    t2 = time.time()
+    print(t1-t0, t2-t1)
 
     fig, ax = plt.subplots()
     ax.plot(fs.spectrum.wave, fs.spectrum.flux, 'g-')

--- a/spexxy/data/vsini.py
+++ b/spexxy/data/vsini.py
@@ -30,6 +30,8 @@ class Vsini:
 
         # get sampling in velocity space
         delta_v = 299792.458 * spec.wave_step
+        if spec.wave_mode == Spectrum.Mode.LOG10LAMBDA:
+            delta_v *= np.log(10)  # convert to natural log
 
         # The line-of sight velocity is split up into the nearest smaller value that corresponds to a shift
         # by an interger number of pixels, and the remaining fractional pixel shift. The latter is applied

--- a/spexxy/data/vsini.py
+++ b/spexxy/data/vsini.py
@@ -21,7 +21,7 @@ class Vsini:
             np.ndarray: Convolved spectrum
         """
         # spectrum in log mode?
-        if spec.wave_mode != Spectrum.Mode.LOGLAMBDA:
+        if spec.wave_mode not in [Spectrum.Mode.LOGLAMBDA, Spectrum.Mode.LOG10LAMBDA]:
             raise ValueError("Spectrum must be on log wavelength.")
 
         # spectrum regularly sampled?

--- a/spexxy/main/paramsfit.py
+++ b/spexxy/main/paramsfit.py
@@ -326,8 +326,8 @@ class ParamsFit(FilesRoutine):
         # if any of the parameters was fitted close to their edge, fit failed
         if self._check_limits:
             for pn in result.params:
-                # ignore all sigma values
-                if pn.lower().find("sig") != -1 or pn.lower().find("tellurics") != -1:
+                # ignore all line broadening or tellurics values
+                if pn.lower().find("sig") != -1 or pn.lower().find("vsini") != -1 or pn.lower().find("tellurics") != -1:
                     continue
 
                 # get param


### PR DESCRIPTION
Added an alternative recipe for fitting spectral line broadening, using rotational broadening (aka Vsini) instead of a Gauss-Hermite LOSVD. To this aim, the [Vsini functions](https://pyastronomy.readthedocs.io/en/latest/pyaslDoc/aslDoc/rotBroad.html) available in the PyAstronomy package are imported.

To use the new routine, the config-file for running spexxy can be modified as follows.
```
components:
  star:
    class: spexxy.component.GridComponent
    broadening_type: VSINI
    init:
    - class: spexxy.init.InitFromValues
      values:
        vsini: 100.0
        epsilon: 0.8
``` 
In this case, all spectrum fits are initialised with a Vsini value of 100 km/s and a limb-darkening parameter of 0.8.

The plot below shows the relation between Vsini and the Gaussian sigma from the analysis of ~2,000 MUSE spectra from the young LMC cluster NGC 1856.
![spexxy_ngc1856_sig_vs_vsini](https://github.com/user-attachments/assets/0e2949ff-cb14-4bd9-97eb-93f69b19928f)
